### PR TITLE
Update to handle alt id

### DIFF
--- a/auth0/Gemfile
+++ b/auth0/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '3.2.2'
 
 gem 'optparse'
 gem 'date'

--- a/auth0/Gemfile.lock
+++ b/auth0/Gemfile.lock
@@ -18,7 +18,7 @@ DEPENDENCIES
   securerandom
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 3.2.2p53
 
 BUNDLED WITH
    2.1.4

--- a/auth0/import.rb
+++ b/auth0/import.rb
@@ -224,6 +224,8 @@ f1.each_line { |line|
   s_hash = JSON.parse(line)
   id = s_hash['_id']['$oid']
   auth0_secrets[id] = s_hash
+
+  # if user was imported to auth0, they will have a non uuid in the users file and an alt_id in the secrets file.
   alt_id = s_hash['alt_id']
   if alt_id
     auth0_secrets[alt_id] = s_hash

--- a/auth0/import.rb
+++ b/auth0/import.rb
@@ -93,7 +93,13 @@ def map_user(id, auth_secret, auth_user, options)
   if is_auth0_user
     # Optionally convert Auth0 user_id to a UUID for FusionAuth
     if $map_auth0_user_id
-      _id = id.ljust(32, '0')
+      id_to_turn_to_uuid = id
+      if id.length != 24
+        # We have an alternate id, loaded from a non Auth0 datasource
+        id_to_turn_to_uuid = auth_secret['_id']['$oid']
+      end
+
+      _id = id_to_turn_to_uuid.ljust(32, '0')
       user['id'] = "#{_id[0, 8]}-#{_id[8, 4]}-#{_id[12, 4]}-#{_id[16, 4]}-#{_id[20, 12]}"
     end
   end
@@ -218,6 +224,8 @@ f1.each_line { |line|
   s_hash = JSON.parse(line)
   id = s_hash['_id']['$oid']
   auth0_secrets[id] = s_hash
+  alt_id = s_hash['alt_id']
+  auth0_secrets[alt_id] = s_hash
 }
 f1.close
 

--- a/auth0/import.rb
+++ b/auth0/import.rb
@@ -225,7 +225,9 @@ f1.each_line { |line|
   id = s_hash['_id']['$oid']
   auth0_secrets[id] = s_hash
   alt_id = s_hash['alt_id']
-  auth0_secrets[alt_id] = s_hash
+  if alt_id
+    auth0_secrets[alt_id] = s_hash
+  end
 }
 f1.close
 


### PR DESCRIPTION
This change should be backwards compatible, but when an auth0 user being imported into FusionAuth has previously been imported into Auth0, their auth0 user id won't be a uuid. It could be an int. Rather than the uuid being the key to join the secrets file and the user file on the id, there will be an 'alt_id' field in the secrets file that corresponds to the non-uuid id value in the users file. 

This change handles that case.

It also upgrades the version of ruby that is required.