### PR TITLE
Fix/insert instant milliseconds

### DIFF
--- a/azureadb2c/Gemfile
+++ b/azureadb2c/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '>= 3.0'
 
 gem 'optparse'
 gem 'date'

--- a/azureadb2c/import.rb
+++ b/azureadb2c/import.rb
@@ -105,7 +105,7 @@ def map_user(id, azure_user, options)
   end
 
   # Incoming format is in ISO string, need to convert to epoch milliseconds for FusionAuth
-  user["insertInstant"] = Time.parse(azure_user["createdDateTime"]).to_i;
+  user["insertInstant"] = Time.parse(azure_user["createdDateTime"]).to_i * 1000;
 
   # Preserve all Azure identities for future reference
   user["data"] = {}


### PR DESCRIPTION
This PR fixes two issues in the Azure AD B2C import script:

- Fixed `insertInstant` to use milliseconds instead of seconds. The FusionAuth API requires milliseconds; the previous value was producing invalid timestamps.
- Updated Gemfile Ruby version pin from `2.7.1` to `>= 3.0`. Ruby 2.7 reached end of life in March 2023.